### PR TITLE
Remove partial duplicate field geo_loc_name_state_province_region

### DIFF
--- a/PHA4GE_SARS-CoV-2_Contextual_Data_Schema.json
+++ b/PHA4GE_SARS-CoV-2_Contextual_Data_Schema.json
@@ -8,7 +8,6 @@
     "isolate",
     "sample_collection_date",
     "host_disease",
-    "geo_loc_name_state_province_region",
     "consensus_sequence_software_name",
     "geo_loc_name_state_province_territory",
     "specimen_collector_sample_id",
@@ -2148,11 +2147,6 @@
       "examples": [
         "SARS-CoV-2/human/USA/CA-CDPH-001/2020,hCoV-19/USA-CDPH-001/2020"
       ]
-    },
-    "geo_loc_name_state_province_region": {
-      "type": "string",
-      "description": "State/province/region of origin of the sample.",
-      "examples": ["Western Cape"]
     },
     "host_health_state": {
       "type": {


### PR DESCRIPTION
`geo_loc_name_state_province_region` appears to be an erroneous duplicate of `geo_loc_name_state_province_territory` in having the same example value, and being absent from the template spreadsheet. I have removed both references to it in the JSON.