### PR TITLE
Remove partial duplicate geo_loc_name_state_province_region (after enum fix)

### DIFF
--- a/PHA4GE_SARS-CoV-2_Contextual_Data_Schema.json
+++ b/PHA4GE_SARS-CoV-2_Contextual_Data_Schema.json
@@ -849,13 +849,6 @@
                 ""
             ]
         },
-        "geo_loc_name_state_province_region": {
-            "description": "State/province/region of origin of the sample.",
-            "type": "string",
-            "examples": [
-                "Western Cape"
-            ]
-        },
         "host_common_name": {
             "description": "The commonly used name of the host.",
             "type": "string",
@@ -2779,7 +2772,6 @@
     },
     "required": [
         "sequence_submitted_by",
-        "geo_loc_name_state_province_region",
         "consensus_sequence_software_name",
         "isolate",
         "sequencing_instrument",


### PR DESCRIPTION
Replaces https://github.com/pha4ge/SARS-CoV-2-Contextual-Data-Specification/pull/12

`geo_loc_name_state_province_region` appears to be an erroneous duplicate of `geo_loc_name_state_province_territory` in having the same example value, and being absent from the template spreadsheet. I have removed both references to it in the JSON.